### PR TITLE
Xcode 11 Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'down'
 gem 'json'
 gem 'plist'
 gem 'xcodeproj'
+gem 'rubyzip'
 
 # Test
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,26 +8,27 @@ GEM
     claide (1.0.3)
     colored2 (3.1.2)
     diff-lcs (1.4.4)
-    down (5.1.1)
+    down (5.2.0)
       addressable (~> 2.5)
     json (2.3.1)
     nanaimo (0.3.0)
     plist (3.5.0)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
+    rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec-expectations (3.9.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
-    xcodeproj (1.17.1)
+    rspec-support (3.9.4)
+    rubyzip (2.3.0)
+    xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -42,6 +43,7 @@ DEPENDENCIES
   json
   plist
   rspec
+  rubyzip
   xcodeproj
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ System libraries and frameworks are linked if they are not present. It’s recom
 
 This step is compatible with all Xcode projects that use Swift only, interoperability (mixed) and Objective-C only languages. 
 
-Note: For Xcode 11 please use the last supported version `1.6.1`. 
-
 Android:
    TBA.
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -31,7 +31,7 @@ workflows:
     envs:
       - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/shams-ahmed/bitrise-steplib.git
       - STEP_ID_IN_STEPLIB: add-trace-sdk
-      - STEP_GIT_VERION_TAG_TO_SHARE: 1.0.4
+      - STEP_GIT_VERION_TAG_TO_SHARE: 1.1.0
       - STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/bitrise-step-add-trace-sdk.git
     before_run:
     - audit-this-step

--- a/spec/step_spec.rb
+++ b/spec/step_spec.rb
@@ -1,3 +1,4 @@
+require 'zip'
 require_relative './../functions.rb'
 
 describe 'download_library' do
@@ -12,6 +13,24 @@ describe 'download_library' do
         lib_version = "latest"
         
         f = download_library("https://monitoring-sdk.firebaseapp.com/#{lib_version}/libTrace.a.zip")
+        expect(f.original_filename).to eq("libTrace.a.zip")
+    end
+
+    it 'validate zip file contains SDK' do
+        lib_version = "latest"
+        hasSDK = false
+
+        f = download_library("https://monitoring-sdk.firebaseapp.com/#{lib_version}/libTrace.a.zip")
+        
+        Zip::File.open(f.path) do |zip_file|
+            zip_file.each do |f|
+                if f.name == "libTrace.a"
+                    hasSDK = true
+                end
+            end
+        end
+
+        expect(hasSDK).to be true
         expect(f.original_filename).to eq("libTrace.a.zip")
     end
 

--- a/spec/step_spec.rb
+++ b/spec/step_spec.rb
@@ -6,7 +6,13 @@ describe 'download_library' do
         
         f = download_library("https://monitoring-sdk.firebaseapp.com/#{lib_version}/libTrace.a")
         expect(f.original_filename).to eq("libTrace.a")
-       
+    end
+
+    it 'returns zip file download is successful' do
+        lib_version = "latest"
+        
+        f = download_library("https://monitoring-sdk.firebaseapp.com/#{lib_version}/libTrace.a.zip")
+        expect(f.original_filename).to eq("libTrace.a.zip")
     end
 
     it 'raises error if url is 404' do

--- a/step.rb
+++ b/step.rb
@@ -1,4 +1,5 @@
 require "fileutils"
+require 'zip'
 require_relative 'project_helper'
 require_relative 'functions'
 
@@ -35,7 +36,7 @@ end
 
 puts "Will start download for version: #{path}"
 
-url = "https://monitoring-sdk.firebaseapp.com/#{path}/libTrace.a"
+url = "https://monitoring-sdk.firebaseapp.com/#{path}/libTrace.a.zip"
 tmpf = download_library(url)
 if tmpf == nil
     puts "Error downloading Bitrise Trace library version #{lib_version} from #{url}: #{e.message}"
@@ -48,7 +49,27 @@ puts
 puts "Starting step with path: #{project_path}, scheme: #{scheme}, trace version: #{lib_version}"
 puts
 
-FileUtils.mv(tmpf.path, "#{File.dirname(project_path)}/#{tmpf.original_filename}")
+fileLocation = "#{File.dirname(project_path)}/#{tmpf.original_filename}"
+FileUtils.mv(tmpf.path, fileLocation)
+
+# Unzip file
+
+puts "Unzipping Trace SDK"
+
+Zip::File.open(fileLocation) do |zip_file|
+    zip_file.each do |f|
+        if f.name == "libTrace.a"
+            fpath = File.join("#{File.dirname(project_path)}", f.name)
+            zip_file.extract(f, fpath) unless File.exist?(fpath)
+            
+            puts "Unzipping: #{fpath}"
+        else 
+            puts "Skipping file: #{f.name}"
+        end
+    end
+end
+
+puts "Unzipped Trace SDK"
 
 helper = ProjectHelper.new(project_path, scheme)
 

--- a/step.rb
+++ b/step.rb
@@ -10,6 +10,7 @@ end
 project_path = ENV['project_path']
 scheme = ENV['scheme']
 lib_version = ENV['lib_version']
+xcode_version = ENV['APM_XCODE_VERSION']
 
 if project_path.empty?
     puts "Error: BITRISE_PROJECT_PATH env var is required and cannot be empty. #{project_path}"
@@ -26,7 +27,15 @@ if lib_version.empty?
     exit 1
 end
 
-url = "https://monitoring-sdk.firebaseapp.com/#{lib_version}/libTrace.a"
+path = lib_version
+
+if ['Xcode 11.5', 'Xcode 11.6', 'Xcode 11.7'].include? xcode_version
+    path += " (Xcode 11.7)" # Xcode 11 builds are built using Xcode 11.7. Update Bitrise stack first
+end
+
+puts "Will start download for version: #{path}"
+
+url = "https://monitoring-sdk.firebaseapp.com/#{path}/libTrace.a"
 tmpf = download_library(url)
 if tmpf == nil
     puts "Error downloading Bitrise Trace library version #{lib_version} from #{url}: #{e.message}"

--- a/step.sh
+++ b/step.sh
@@ -11,6 +11,11 @@ gem install "plist" --silent
 gem install "xcodeproj" --silent
 
 echo "Installed step dependencies"
+echo "Checking Xcode version"
+
+export APM_XCODE_VERSION=$(xcodebuild -version | grep 'Xcode\s[0-9.]*')
+
+echo "Xcode version: ${APM_XCODE_VERSION}"
 
 echo "Running Trace step"
 

--- a/step.sh
+++ b/step.sh
@@ -9,6 +9,7 @@ gem install "down" --silent
 gem install "json" --silent
 gem install "plist" --silent
 gem install "xcodeproj" --silent
+gem install "rubyzip" --silent
 
 echo "Installed step dependencies"
 echo "Checking Xcode version"

--- a/step.yml
+++ b/step.yml
@@ -12,8 +12,6 @@ description: |
     System libraries and frameworks are linked if they are not present. It’s recommended to add this step just before the Xcode build and archive step. 
     This step is compatible with all Xcode projects that use Swift only, interoperability (mixed) and Objective-C only languages. 
 
-    Note: For Xcode 11 please use the version `1.6.1`. 
-
     Source code for the iOS SDK can be found here: https://github.com/bitrise-io/trace-cocoa-sdk
 
   Android:
@@ -57,7 +55,6 @@ inputs:
       summary: The version of the Bitrise Trace SDK to link into the app.
       description: |-
         The version of the Bitrise Trace SDK to link into the app. 
-        Note: For Xcode 11 please use the last supported version `1.6.1`. 
       
         List of available releases for Apple related platforms: https://github.com/bitrise-io/trace-cocoa-sdk/releases
       is_required: true


### PR DESCRIPTION
- Support download zip file instead of the raw SDK as its half the size
- Xcode 11.5, 11.6, 11.7 support
- Logs update
- Tests
- Gem update